### PR TITLE
Remove redundant constraints from Raku attributes

### DIFF
--- a/raku/lib/Knight/Function.rakumod
+++ b/raku/lib/Knight/Function.rakumod
@@ -12,10 +12,10 @@ use Knight::NonIdempotent;
 unit class Knight::Function does Knight::Value does Knight::NonIdempotent;
 
 #| The function associated with this instance.
-has #`(Callable) &!func is built;
+has &!func is built;
 
 #| The arguments to pass to the function.
-has #`(Array[Knight::Value]) @!args is built;
+has Knight::Value @!args is built;
 
 my %FUNCS;
 


### PR DESCRIPTION
The `&` sigil already imposes a Callable type constraint, just like the `@` sigil imposes a Positional constraint

    $ raku -e 'my Callable $callable = -> { "Hello" }'
    $ raku -e 'my Callable $callable = 1'
    Type check failed in assignment to $callable; expected Callable but got Int (1)
      in block <unit> at -e line 1
    $ raku -e 'my &callable = -> { "Hello" }'
    $ raku -e 'my &callable = 1'
    Type check failed in assignment to &callable; expected Callable but got Int (1)
      in block <unit> at -e line 1